### PR TITLE
Fix processor test debug output

### DIFF
--- a/tests/lib/processor.test.ts
+++ b/tests/lib/processor.test.ts
@@ -133,7 +133,6 @@ describe('processPath', () => {
         p === path.resolve(baseProjectPath, 'node_modules') ||
         p === path.resolve(baseProjectPath, 'build')
       ) {
-        console.log(`DEBUG: fsp.stat mock returning DIRECTORY for ${p}`); // Add this
         return createMockStats(false, true);
       }
 


### PR DESCRIPTION
## Summary
- remove stray `console.log` debug line from processor test

## Testing
- `npm test` *(fails: cannot find type definition file)*